### PR TITLE
Added MCST

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ As well as some other IBM internal compilers, and LLVM projects.
 
 * GCC contributions
 
+## [MCST](http://www.mcst.ru/vakansis)
+🗺  _Moscow, Russia_
+
+* [LCC](http://www.mcst.ru/lcc) optimizing compiler for MCST's chips
+* Binary translator from x86 to own ISA Elbrus
+
 ## [MediaTek](https://www.mediatek.com/careers/careers)
 🗺 _Woburn, MA, USA_
 


### PR DESCRIPTION
MCST is a Russian company, which creates chips with its own Elbrus ISA (VLIW) and SPARC ISA.
Both links are in Russian.