### PR TITLE
Updates Jetbrains locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ As well as some other IBM internal compilers, and LLVM projects.
 
 ## [Jetbrains](https://www.jetbrains.com/careers/apply/)
 
-🗺 _Munich & Berlin Germany, Prague Czech Republic, Amsterdam Netherlands, Cyprus, Serbia, Armenia (many other locations for non-compiler jobs)_
+🗺 _Munich & Berlin Germany, Prague Czech Republic, Amsterdam Netherlands, Cyprus, Serbia, Armenia (other locations for non-compiler jobs)_
 
 * Kotlin
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ As well as some other IBM internal compilers, and LLVM projects.
 
 ## [Jetbrains](https://www.jetbrains.com/careers/apply/)
 
-🗺 _Saint Petersburg, Russia_
+🗺 _Munich & Berlin Germany, Prague Czech Republic, Amsterdam Netherlands, Cyprus, Serbia, Armenia (many other locations for non-compiler jobs)_
 
 * Kotlin
 


### PR DESCRIPTION
Jetbrains no longer operates in Russia due to the war in Ukraine: https://blog.jetbrains.com/blog/2022/03/11/jetbrains-statement-on-ukraine/

They have a very large number of locations, even beyond the 7 they list on this [page](https://www.jetbrains.com/company/contacts/#headquarters-international-sales), so I went based off of the locations listed for a Senior Compiler [position ](https://www.jetbrains.com/careers/jobs/senior-developer-kotlin-compiler-team-533/) I found. Since it's only one position I don't think that this is exhaustive.

I also don't know what to make of the fact that they listed the entire countries of Cyprus, Serbia, and Armenia, whereas for their other locations they listed specific cities. I just copied it in wholesale.