### PR TITLE
Deno: strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,6 @@ Work on the Programming Models and Compilers (PMC) group of the Computational Sc
 
 * Deep Learning Compiler for NPU hardware
 
-## [Deno](https://jobs.ashbyhq.com/Deno) 📤
-* JavaScript runtime and tools written in Rust
-
 ## [Distributive](https://distributive.network) 📤
 🗺  Kingston, ON (Canada)
 


### PR DESCRIPTION
The link is broken, and it's unclear if there are open positions accessible from deno.com.