### PR TITLE
Update Julia Computing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ Other internal language-oriented projects include work on a [Haxl](https://hacka
 
 * J programming language
 
-## [Julia Computing](https://juliacomputing.com/communication/jobs) 📤🧑‍🎓
+## [Julia Computing](https://juliahub.com/company/jobs) 📤🧑‍🎓
 🗺 _Boston, MA_ 
 
 * Development of [Julia](https://julialang.org/)


### PR DESCRIPTION
It seems that they changed their base url / website to being juliahub.com