### PR TITLE
Add HTEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Innumerable projects, but off the top of my head:
 * Cray Programming Environment, a suite of Fortran, C and C++ compilers
 * LLVM contributions
 
-## [HTEC](https://htec.com/careers/jobs) 🧑‍🎓
+## [HTEC](https://htec.com/careers/jobs) 📤🧑‍🎓
 🗺 _Serbia, Bosnia and Herzegovina, North Macedonia, Hungary, Croatia, Spain, Czech Republic_
 
 * LLVM/Clang and GCC optimization passes and backend support for new architectures

--- a/README.md
+++ b/README.md
@@ -411,6 +411,13 @@ Innumerable projects, but off the top of my head:
 * Cray Programming Environment, a suite of Fortran, C and C++ compilers
 * LLVM contributions
 
+## [HTEC](https://htec.com/careers/jobs) 🧑‍🎓
+🗺 _Serbia, Bosnia and Herzegovina, North Macedonia, Hungary, Croatia, Spain, Czech Republic_
+
+* LLVM/Clang and GCC optimization passes and backend support for new architectures
+* AI/ML compiler development
+* Linker, debugger, and profiler tooling
+
 ## [Huawei](https://www.huawei.com/ch-en/about-huawei/careers) 
 
 * Research and Development work in compilers and runtime systems.


### PR DESCRIPTION
HTEC has an open job post for compiler work: https://htec.com/careers/jobs/#compiler-toolchain-engineer-HPO
As well as rolling internships: https://htec.com/careers/internship/#software-engineering-internships-ai-compilers-system-software-HPM
Remote work is confirmed in their FAQ section at https://htec.com/careers/jobs/

The full-time role is available across the countries listed in the entry's location line, and is remote-eligible. Though the internship appears to be limited to Serbia and Bosnia and Herzegovina, and is not remote.